### PR TITLE
Add ability to test 'current' pager items in PL

### DIFF
--- a/components/_patterns/02-molecules/pager/pager.yml
+++ b/components/_patterns/02-molecules/pager/pager.yml
@@ -10,3 +10,4 @@ items:
       href: "#"
   previous: true
   next: true
+current: 2


### PR DESCRIPTION
**What:**

Adds a single new yml key to `pager.yml`:  `current: 2`.

**Why:**

Allows a developer to visually test for the "current page" within the pager element.

**How:**

No other changes!

**To Test:**
- Set `current` to a positive value
- add a style for `.pager__item.is-active` and `.pager__link.is-active`
- look at it. :)
